### PR TITLE
Remove unnecessary/errant nul-termination of resulting digest (hash_out) buffer.

### DIFF
--- a/sha1.c
+++ b/sha1.c
@@ -291,6 +291,5 @@ void SHA1(
     for (ii=0; ii<len; ii+=1)
         SHA1Update(&ctx, (const unsigned char*)str + ii, 1);
     SHA1Final((unsigned char *)hash_out, &ctx);
-    hash_out[20] = '\0';
 }
 


### PR DESCRIPTION
`hash_out` is not a NUL-terminated string, it's just 20 bytes of any value so null-termination make no sense in this context.

Additionally, by NUL-terminating, you're requiring that the `hash_out` be 21 bytes (168 bits) in length, when a SHA-1 digest is actually 160 bits (20 bytes) in length.