### PR TITLE
Make SHA1 receive uint32_t & Add -Wextra flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TESTCFLAGS=-g -Wall -Werror
+TESTCFLAGS=-g -Wall -Wextra -Werror
 TESTLINKER=-lcunit
 TESTSOURCES=test.c sha1.c
 TESTBINARY=sha1test

--- a/sha1.c
+++ b/sha1.c
@@ -282,7 +282,7 @@ void SHA1Final(
 void SHA1(
     char *hash_out,
     const char *str,
-    int len)
+    uint32_t len)
 {
     SHA1_CTX ctx;
     unsigned int ii;

--- a/sha1.h
+++ b/sha1.h
@@ -43,7 +43,7 @@ void SHA1Final(
 void SHA1(
     char *hash_out,
     const char *str,
-    int len);
+    uint32_t len);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
This suppresses the following warning when compiling with `-Wextra`:
```
sha1.c:291:18: error: comparison of integer expressions of different signedness: 'unsigned int' and 'int' [-Werror=sign-compare]
  291 |     for (ii=0; ii<len; ii+=1)
```
It would generally be a good idea to use `size_t` for all byte counts, but there could be a reason why it was done this way instead.