### PR TITLE
Drop stdio.h include

### DIFF
--- a/sha1.c
+++ b/sha1.c
@@ -17,7 +17,6 @@ A million repetitions of "a"
 
 #define SHA1HANDSOFF
 
-#include <stdio.h>
 #include <string.h>
 
 /* for uint32_t */


### PR DESCRIPTION
The sha1.c file includes stdio.h without seemingly using it for anyhing. It doesn't make sense for a hash library to use stdio and having that header included makes it harder to use the library in freestanding environment.

Drop the include to make it easier to use the library in freestanding projects.

Closes #13 